### PR TITLE
Follow Mode

### DIFF
--- a/cmd/subcommands/acci-ping/controls.go
+++ b/cmd/subcommands/acci-ping/controls.go
@@ -1,0 +1,76 @@
+// Use of this source code is governed by a GPL-2 license that can be found in the LICENSE file.
+//
+// Copyright 2025 Lexer747
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package acciping
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/Lexer747/acci-ping/draw"
+	"github.com/Lexer747/acci-ping/graph"
+	"github.com/Lexer747/acci-ping/graph/terminal"
+	"github.com/Lexer747/acci-ping/gui"
+)
+
+// showControls which should only be called once the paint buffer is initialised.
+func (app *Application) showControls(
+	ctx context.Context,
+	controls <-chan graph.Control,
+	terminalSizeUpdates <-chan terminal.Size,
+) {
+	buffer := app.drawBuffer.Get(draw.ControlIndex)
+	c := controlState{following: false} // TODO when added to config populate it here too
+	app.paint(c.render(app.term.GetSize(), buffer))
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case newSize := <-terminalSizeUpdates:
+			app.paint(c.render(newSize, buffer))
+		case update := <-controls:
+			if update.FollowLatestSpan {
+				c.following = !c.following
+			}
+			app.paint(c.render(app.term.GetSize(), buffer))
+		}
+	}
+}
+
+type controlState struct {
+	following bool
+}
+
+func (c controlState) render(size terminal.Size, buf *bytes.Buffer) paintUpdate {
+	ret := None
+	shouldInvalidate := buf.Len() != 0
+	if shouldInvalidate {
+		ret = ret | Invalidate
+	}
+	buf.Reset()
+	if c.following {
+		box := c.makeControlBox()
+		box.Draw(size, buf)
+		return ret | Paint
+	}
+	return ret
+}
+
+func (c controlState) makeControlBox() gui.Box {
+	return gui.Box{
+		BoxText: []gui.Typography{{
+			ToPrint:        "Following",
+			LenFromToPrint: true,
+			Alignment:      gui.Right,
+		}},
+		Position: gui.Position{
+			Vertical:   gui.Top,
+			Horizontal: gui.Right,
+			Padding:    gui.Padding{Left: 4, Bottom: 0},
+		},
+		Style: gui.NoBorder,
+	}
+}

--- a/cmd/subcommands/acci-ping/errorToast.go
+++ b/cmd/subcommands/acci-ping/errorToast.go
@@ -21,7 +21,7 @@ import (
 )
 
 // toastNotifications which should only be called once the paint buffer is initialised.
-func (app *Application) toastNotifications(ctx context.Context, terminalSizeUpdates chan terminal.Size) {
+func (app *Application) toastNotifications(ctx context.Context, terminalSizeUpdates <-chan terminal.Size) {
 	store := toastStore{
 		Mutex:  &sync.Mutex{},
 		toasts: map[int]toast{},
@@ -129,7 +129,7 @@ func makeBox(ts []toast) gui.Box {
 	return gui.Box{
 		BoxText: text,
 		Position: gui.Position{
-			Vertical:   gui.Centre,
+			Vertical:   gui.Middle,
 			Horizontal: gui.Centre,
 			Padding:    gui.NoPadding,
 		},

--- a/cmd/subcommands/acci-ping/help.go
+++ b/cmd/subcommands/acci-ping/help.go
@@ -20,8 +20,8 @@ import (
 func (app *Application) help(
 	ctx context.Context,
 	startShowHelp bool,
-	helpChannel chan rune,
-	terminalSizeUpdates chan terminal.Size,
+	helpChannel <-chan rune,
+	terminalSizeUpdates <-chan terminal.Size,
 ) {
 	helpBuffer := app.drawBuffer.Get(draw.HelpIndex)
 	h := help{showHelp: startShowHelp}
@@ -62,7 +62,7 @@ func (h help) render(size terminal.Size, buf *bytes.Buffer) paintUpdate {
 	return ret
 }
 
-func helpAction(ch chan rune) func(r rune) error {
+func helpAction(ch chan<- rune) func(r rune) error {
 	return func(r rune) error {
 		ch <- r
 		return nil
@@ -73,7 +73,7 @@ func (h help) makeHelpBox() gui.Box {
 	return gui.Box{
 		BoxText: helpCopy,
 		Position: gui.Position{
-			Vertical:   gui.Centre,
+			Vertical:   gui.Middle,
 			Horizontal: gui.Right,
 			Padding:    gui.Padding{Left: 4},
 		},
@@ -85,5 +85,6 @@ var helpCopy = []gui.Typography{
 	{ToPrint: ansi.Yellow("Help"), TextLen: 4, Alignment: gui.Centre},
 	{ToPrint: "", TextLen: 0, Alignment: gui.Centre},
 	{ToPrint: "Press " + ansi.Green("ctrl+c") + " to exit.", TextLen: 6 + 6 + 9, Alignment: gui.Left},
+	{ToPrint: "Press " + ansi.Green("f") + " to follow the most recent data.", TextLen: 6 + 1 + 32, Alignment: gui.Left},
 	{ToPrint: "Press " + ansi.Green("h") + " to open/close this window.", TextLen: 6 + 1 + 27, Alignment: gui.Left},
 }

--- a/draw/draw.go
+++ b/draw/draw.go
@@ -47,6 +47,7 @@ var (
 	DataIndex     = newIndex()
 	GradientIndex = newIndex()
 	HelpIndex     = newIndex()
+	ControlIndex  = newIndex()
 	KeyIndex      = newIndex()
 	SpinnerIndex  = newIndex()
 	ToastIndex    = newIndex()
@@ -70,6 +71,7 @@ var PaintOrder = []Index{
 	KeyIndex,
 	// Notifications can appear above the graph as they're ephemeral
 	ToastIndex,
+	ControlIndex,
 	HelpIndex,
 	// if we can't see the spinner we may be worried the program is dead
 	SpinnerIndex,
@@ -77,9 +79,10 @@ var PaintOrder = []Index{
 
 // GraphIndexes is the [PaintOrder] with the GUI indexes removed
 var GraphIndexes = sliceutils.Remove(PaintOrder,
-	ToastIndex,
+	ControlIndex,
 	HelpIndex,
 	SpinnerIndex,
+	ToastIndex,
 )
 
 // GUIIndexes is the above paint order with the GraphIndexes indexes removed

--- a/graph/export_test.go
+++ b/graph/export_test.go
@@ -21,7 +21,7 @@ func (g *Graph) AddPoint(p ping.PingResults) {
 
 func (g *Graph) ComputeFrame() string {
 	var b strings.Builder
-	painter := g.computeFrame(0, false)
+	painter := g.computeFrame(0, false, false)
 	err := painter(&b)
 	check.NoErr(err, "While painting frame to string buffer")
 	return b.String()

--- a/graph/graph_file_test.go
+++ b/graph/graph_file_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/Lexer747/acci-ping/graph/terminal"
 	termTh "github.com/Lexer747/acci-ping/graph/terminal/th"
 	graphTh "github.com/Lexer747/acci-ping/graph/th"
-	"github.com/Lexer747/acci-ping/gui"
 	"github.com/Lexer747/acci-ping/ping"
 	"github.com/Lexer747/acci-ping/utils/env"
 	"gotest.tools/v3/assert"
@@ -188,7 +187,13 @@ func produceFrame(t *testing.T, size terminal.Size, data *data.Data, terminalWra
 	assert.NilError(t, err)
 	pingChannel := make(chan ping.PingResults)
 	close(pingChannel)
-	g := graph.NewGraphWithData(ctx, pingChannel, term, gui.NoGUI(), 0, data, draw.NewPaintBuffer(), true)
+	g := graph.NewGraph(ctx, graph.GraphConfiguration{
+		Input:         pingChannel,
+		Terminal:      term,
+		DrawingBuffer: draw.NewPaintBuffer(),
+		DebugStrict:   true,
+		Data:          data,
+	})
 	defer func() { stdin.WriteCtrlC(t) }()
 	output := makeBuffer(size)
 	return playAnsiOntoStringBuffer(g.ComputeFrame(), output, size, terminalWrapping)

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/Lexer747/acci-ping/graph"
 	"github.com/Lexer747/acci-ping/graph/terminal"
 	"github.com/Lexer747/acci-ping/graph/terminal/th"
-	"github.com/Lexer747/acci-ping/gui"
 	"github.com/Lexer747/acci-ping/ping"
 	"github.com/Lexer747/acci-ping/utils/env"
 	"gotest.tools/v3/assert"
@@ -250,7 +249,12 @@ func initTestGraph(t *testing.T, size terminal.Size) (*graph.Graph, func(), erro
 	assert.NilError(t, err)
 	pingChannel := make(chan ping.PingResults)
 	defer close(pingChannel)
-	g := graph.NewGraph(ctx, pingChannel, term, gui.NoGUI(), 0, "", draw.NewPaintBuffer(), true)
+	g := graph.NewGraph(ctx, graph.GraphConfiguration{
+		Input:         pingChannel,
+		Terminal:      term,
+		DrawingBuffer: draw.NewPaintBuffer(),
+		DebugStrict:   true,
+	})
 	return g, func() { stdin.WriteCtrlC(t) }, err
 }
 

--- a/graph/graphdata/graphdata_test.go
+++ b/graph/graphdata/graphdata_test.go
@@ -173,7 +173,7 @@ func (test BasicTimeSpanTest) Run(t *testing.T) {
 
 func assertEveryPointHasSpan(t *testing.T, gd *graphdata.GraphData, actual []*graphdata.SpanInfo) {
 	t.Helper()
-	iter := gd.LockFreeIter()
+	iter := gd.LockFreeIter(false)
 	for i := range iter.Total {
 		p := iter.Get(i)
 		timestamp := p.Timestamp

--- a/graph/terminal/terminal.go
+++ b/graph/terminal/terminal.go
@@ -368,8 +368,8 @@ func (t *Terminal) processListenedRune(r rune) {
 
 func (t *Terminal) listen(
 	ctx context.Context,
-	listenChannel chan listenResult,
-	processingChannel chan struct{},
+	listenChannel chan<- listenResult,
+	processingChannel <-chan struct{},
 	buffer []byte,
 ) {
 	defer close(listenChannel)

--- a/graph/xAxis.go
+++ b/graph/xAxis.go
@@ -1,0 +1,256 @@
+// Use of this source code is governed by a GPL-2 license that can be found in the LICENSE file.
+//
+// Copyright 2024-2025 Lexer747
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graph
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/Lexer747/acci-ping/graph/data"
+	"github.com/Lexer747/acci-ping/graph/graphdata"
+	"github.com/Lexer747/acci-ping/graph/terminal"
+	"github.com/Lexer747/acci-ping/graph/terminal/ansi"
+	"github.com/Lexer747/acci-ping/graph/terminal/typography"
+	"github.com/Lexer747/acci-ping/ping"
+	"github.com/Lexer747/acci-ping/utils/numeric"
+	"github.com/Lexer747/acci-ping/utils/sliceutils"
+)
+
+type drawingYAxis struct {
+	size      int
+	stats     *data.Stats
+	labelSize int
+}
+
+type XAxisSpanInfo struct {
+	spans     []*graphdata.SpanInfo
+	spanStats *data.Stats
+	pingStats *data.Stats
+	timeSpan  *data.TimeSpan
+	startX    int
+	endX      int
+	width     int
+}
+
+type drawingXAxis struct {
+	size        int
+	spans       []*XAxisSpanInfo
+	overallSpan *data.TimeSpan
+}
+
+type xAxisIter struct {
+	*drawingXAxis
+	spanIndex int
+}
+
+func (x drawingXAxis) NewIter() *xAxisIter {
+	return &xAxisIter{
+		drawingXAxis: &x,
+		spanIndex:    0,
+	}
+}
+
+func (x *xAxisIter) Get(p ping.PingDataPoint) *XAxisSpanInfo {
+	currentSpan := x.spans[x.spanIndex]
+	if currentSpan.timeSpan.Contains(p.Timestamp) {
+		return currentSpan
+	}
+	x.spanIndex++
+	return x.Get(p)
+}
+
+func computeXAxis(
+	toWriteTo, toWriteSpanBars *bytes.Buffer,
+	s terminal.Size,
+	overall *data.TimeSpan,
+	spans []*graphdata.SpanInfo,
+	followLatestSpan bool,
+	total int,
+) drawingXAxis {
+	padding := ansi.White(typography.Horizontal)
+	origin := ansi.Magenta(typography.Bullet) + " "
+	space := s.Width - 6
+	remaining := space
+	// First add the initial dot for A E S T H E T I C S
+	fmt.Fprint(toWriteTo, ansi.CursorPosition(s.Height, 1)+origin+padding+padding+padding+padding)
+
+	var xAxisSpans []*XAxisSpanInfo
+	if followLatestSpan {
+		singleSpans := spans[len(spans)-1:]
+		xAxisSpans = []*XAxisSpanInfo{
+			{
+				spans:     singleSpans,
+				spanStats: singleSpans[0].SpanStats,
+				pingStats: singleSpans[0].PingStats,
+				timeSpan:  singleSpans[0].TimeSpan,
+				startX:    1,
+				endX:      s.Width,
+				width:     s.Width,
+			},
+		}
+		overall = singleSpans[0].TimeSpan
+	} else {
+		xAxisSpans = combineSpansPixelWise(spans, space, total)
+		if space <= 1 {
+			for _, span := range xAxisSpans {
+				span.startX = 1
+				span.endX = 1
+			}
+			return drawingXAxis{
+				size:        s.Width,
+				spans:       xAxisSpans,
+				overallSpan: overall,
+			}
+		}
+	}
+
+	// Now we need to iterate every "span", where a span is some pre-determined gap in the pings which is
+	// considered so large that we are reasonably confident that it was another recording session.
+	//
+	// In each iteration, we must determine the time in which the span lives and how much terminal space it
+	// should take up. And then the actual values so that we actually plot against this axis accurately.
+	for _, span := range xAxisSpans {
+		span.startX = min(s.Width, s.Width-remaining)
+
+		start, times := span.timeSpan.FormatDraw(span.width, 2)
+		if len(times) < 1 {
+			toCrop := max(min(span.width-2, len(start)-1), 0)
+			cropped := start[:toCrop]
+			remaining -= len(cropped) + 2
+			fmt.Fprintf(toWriteTo, "%s", ansi.Cyan(cropped))
+			toWriteTo.WriteString(padding + padding)
+		} else {
+			remaining -= len(start) + 4 + 2
+			fmt.Fprintf(toWriteTo, "[ %s ]", ansi.Cyan(start))
+			toWriteTo.WriteString(padding + padding)
+			remaining = xAxisDrawTimes(toWriteTo, times, remaining, padding)
+		}
+
+		span.endX = min(s.Width, s.Width-remaining)
+	}
+	// Finally we add these vertical bars to indicate that the axis is not continuous and a new graph is
+	// starting.
+	if len(xAxisSpans) > 1 {
+		addYAxisVerticalSpanIndicator(toWriteSpanBars, s, xAxisSpans)
+	}
+	return drawingXAxis{
+		size:        s.Width,
+		spans:       xAxisSpans,
+		overallSpan: overall,
+	}
+}
+
+// combineSpansPixelWise is a very crucial pre-processing step we need to do before drawing a frame, the data
+// storage part [graphdata.GraphData] of the program will have made fairly sensible decisions about which
+// parts of the data were actually recorded together. However this part of the program doesn't have the
+// context about how much pixel real estate we can grant per recording session. Therefore we must do this
+// every frame to determine which of this recording sessions must be merged for the sake of drawing. I.e. we
+// have 5 recording sessions [*graphdata.SpanInfo], but the middle two are so short they would only take up 1
+// pixel in the x-axis. This function has the agency to combine those middle spans when creating the
+// [XAxisSpanInfo].
+func combineSpansPixelWise(spans []*graphdata.SpanInfo, startingWidth, total int) []*XAxisSpanInfo {
+	retSpans := make([]*XAxisSpanInfo, 0, len(spans))
+	// TODO make this configurable - right now we just use a percentage of the start width or 5 when the
+	// screen is small.
+	minPixels := max(int(float64(startingWidth)*0.05), 5)
+	acc := 0.0
+	idx := 0
+	for _, span := range spans {
+		ratio := float64(span.Count) / (float64(total))
+		width := int(float64(startingWidth) * ratio)
+		if width >= minPixels && acc == 0.0 {
+			retSpans = append(retSpans, &XAxisSpanInfo{
+				spans:     []*graphdata.SpanInfo{span},
+				spanStats: span.SpanStats,
+				pingStats: span.PingStats,
+				timeSpan:  span.TimeSpan,
+				width:     width,
+			})
+			idx++
+			continue
+		}
+		width = int(float64(startingWidth) * (acc + ratio))
+		if width >= minPixels {
+			retSpans[idx].spans = append(retSpans[idx].spans, span)
+			retSpans[idx].spanStats = retSpans[idx].spanStats.Merge(span.SpanStats)
+			retSpans[idx].pingStats = retSpans[idx].pingStats.Merge(span.PingStats)
+			retSpans[idx].timeSpan = retSpans[idx].timeSpan.Merge(span.TimeSpan)
+			retSpans[idx].width = width
+			acc = 0.0
+			idx++
+			continue
+		}
+		if acc == 0.0 {
+			retSpans = append(retSpans, &XAxisSpanInfo{
+				spans:     []*graphdata.SpanInfo{span},
+				spanStats: span.SpanStats,
+				pingStats: span.PingStats,
+				timeSpan:  span.TimeSpan,
+			})
+		} else {
+			retSpans[idx].spans = append(retSpans[idx].spans, span)
+			retSpans[idx].spanStats = retSpans[idx].spanStats.Merge(span.SpanStats)
+			retSpans[idx].pingStats = retSpans[idx].pingStats.Merge(span.PingStats)
+			retSpans[idx].timeSpan = retSpans[idx].timeSpan.Merge(span.TimeSpan)
+		}
+		acc += ratio
+	}
+	// TODO this width expanding finalizing still leaves some of the terminal unfilled, fix that.
+	totalWidth := sliceutils.Fold(retSpans, 0, func(x *XAxisSpanInfo, acc int) int { return x.width + acc })
+	delta := startingWidth - totalWidth
+	toAdd := delta / len(retSpans)
+	for _, span := range retSpans {
+		span.width += toAdd
+		totalWidth += toAdd
+	}
+	delta = startingWidth - totalWidth
+	retSpans[len(retSpans)-1].width += delta
+	return retSpans
+}
+
+func xAxisDrawTimes(b *bytes.Buffer, times []string, remaining int, padding string) int {
+	for _, point := range times {
+		if remaining <= len(point) {
+			break
+		}
+		b.WriteString(ansi.Yellow(point))
+		remaining -= len(point)
+		if remaining <= 1 {
+			break
+		}
+		b.WriteString(padding)
+		remaining--
+		if remaining <= 1 {
+			break
+		}
+		b.WriteString(padding)
+		remaining--
+	}
+	return remaining
+}
+
+func getX(t time.Time, span *XAxisSpanInfo, y drawingYAxis, s terminal.Size) int {
+	newMin := min(max(1, s.Width-1), span.endX)
+	newMax := max(y.labelSize, span.startX)
+	timestamp := span.timeSpan.End.Sub(t)
+	if span.pingStats.GoodCount+span.spanStats.PacketsDropped <= 1 {
+		// Edge case, when we have exactly one datum but the overall graph has more than one datum so we
+		// didn't short-circuit and need to draw this one point in an arbitrary point between the spans start
+		// and end.
+		return int(numeric.NormalizeToRange(0.5, 0, 1, float64(newMin), float64(newMax)))
+	}
+	// These are inverted deliberately since the drawing reference is symmetric in the x
+	computed := int(numeric.NormalizeToRange(
+		float64(timestamp),
+		0,
+		float64(span.timeSpan.Duration),
+		float64(newMin),
+		float64(newMax),
+	))
+	return computed
+}

--- a/graph/yAxis.go
+++ b/graph/yAxis.go
@@ -1,0 +1,80 @@
+// Use of this source code is governed by a GPL-2 license that can be found in the LICENSE file.
+//
+// Copyright 2024-2025 Lexer747
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graph
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/Lexer747/acci-ping/graph/data"
+	"github.com/Lexer747/acci-ping/graph/terminal"
+	"github.com/Lexer747/acci-ping/graph/terminal/ansi"
+	"github.com/Lexer747/acci-ping/graph/terminal/typography"
+	"github.com/Lexer747/acci-ping/utils/numeric"
+	"github.com/Lexer747/acci-ping/utils/timeutils"
+)
+
+var spanBar = ansi.Cyan(typography.DoubleVertical)
+
+func addYAxisVerticalSpanIndicator(bars *bytes.Buffer, s terminal.Size, spans []*XAxisSpanInfo) {
+	spanSeparator := makeBar(spanBar, s, true)
+	// Don't draw the last span since this is implied by the end of the terminal
+	for _, span := range spans[:len(spans)-1] {
+		if span.endX >= (s.Width - 1) {
+			continue
+			// Don't draw on-top of the y-axis
+		}
+		bars.WriteString(ansi.CursorPosition(2, span.endX+1) + spanSeparator)
+	}
+	// Reset the cursor back to the start of the axis
+	bars.WriteString(ansi.CursorPosition(s.Height, 1))
+}
+
+func computeYAxis(toWriteTo *bytes.Buffer, size terminal.Size, stats *data.Stats, url string) drawingYAxis {
+	toWriteTo.Grow(size.Height)
+
+	makeTitle(toWriteTo, size, stats, url)
+
+	gapSize := 2
+	if size.Height > 20 {
+		gapSize++
+	}
+	durationSize := (gapSize * 3) / 2
+
+	// We skip the first and last two lines
+	for i := range size.Height - 3 {
+		h := i + 2
+		fmt.Fprint(toWriteTo, ansi.CursorPosition(h, 1))
+		if i%gapSize == 1 {
+			scaledDuration := numeric.NormalizeToRange(float64(i), float64(size.Height-2), 0, float64(stats.Min), float64(stats.Max))
+			toPrint := timeutils.HumanString(time.Duration(scaledDuration), durationSize)
+			fmt.Fprint(toWriteTo, ansi.Yellow(toPrint))
+		} else {
+			fmt.Fprint(toWriteTo, ansi.White(typography.Vertical))
+		}
+	}
+	// Last line is always a bar
+	fmt.Fprint(toWriteTo, ansi.CursorPosition(max(1, size.Height-1), 1)+ansi.White(typography.Vertical))
+	return drawingYAxis{
+		size:      size.Height,
+		stats:     stats,
+		labelSize: min(durationSize+4, size.Width),
+	}
+}
+
+func getY(dur time.Duration, yAxis drawingYAxis, s terminal.Size) int {
+	newMin := max(1, s.Height-2)
+	newMax := min(2, s.Height)
+	return int(numeric.NormalizeToRange(
+		float64(dur),
+		float64(yAxis.stats.Min),
+		float64(yAxis.stats.Max),
+		float64(newMin),
+		float64(newMax),
+	))
+}

--- a/gui/no_gui.go
+++ b/gui/no_gui.go
@@ -11,6 +11,7 @@ var _ GUI = (&noGUI{})
 type noGUI struct {
 }
 
+// NoGUI is a gui implementation which never does any work or asks for any work to be done. Useful for tests.
 func NoGUI() GUI {
 	return noGUI{}
 }

--- a/gui/typography.go
+++ b/gui/typography.go
@@ -13,43 +13,54 @@ import (
 	"github.com/Lexer747/acci-ping/graph/terminal"
 )
 
+// Typography implements the [Draw] interface and knows how to draw text to the screen. Note that it only
+// knows how to do a single unbroken line of text, for multi line strings you should use a [Box].
 type Typography struct {
+	// ToPrint is the actual text to print.
 	ToPrint string
 	// TextLen isn't always equal to len(ToPrint) because of unicode characters and ansi control characters
 	// hence why it's a separate field.
 	TextLen int
-	// LenFromToPrint if true will cause the draw call to always overwrite TextLen with len(ToPrint)
+	// LenFromToPrint if true will cause the draw call to always overwrite TextLen with len(ToPrint), safe to
+	// use if no ansi (e.g. [ansi.Green]) colours are used.
 	LenFromToPrint bool
-	Alignment      Alignment
+	Alignment      HorizontalAlignment
 }
 
-func (t Typography) init(maxTextLength int) iTypography {
-	return iTypography{
+func (t Typography) init(maxTextLength int) initialisedTypography {
+	return initialisedTypography{
 		Typography:    t,
 		maxTextLength: maxTextLength,
 	}
 }
 
-type iTypography struct {
+type initialisedTypography struct {
 	Typography
 	maxTextLength int
 }
 
-func (t iTypography) Draw(size terminal.Size, b *bytes.Buffer) {
-	if t.TextLen > t.maxTextLength {
+func (t Typography) Len() int {
+	if t.LenFromToPrint {
+		return len(t.ToPrint)
+	}
+	return t.TextLen
+}
+
+func (t initialisedTypography) Draw(size terminal.Size, b *bytes.Buffer) {
+	if t.Len() > t.maxTextLength {
 		b.WriteString(t.ToPrint)
 		return
 	}
 	switch t.Alignment {
 	case Centre:
-		padding := (t.maxTextLength - t.TextLen) / 2
-		leftPadding, rightPadding := getLeftRightPadding(padding, padding, t.TextLen, t.maxTextLength)
+		padding := (t.maxTextLength - t.Len()) / 2
+		leftPadding, rightPadding := getLeftRightPadding(padding, padding, t.Len(), t.maxTextLength)
 		b.WriteString(strings.Repeat(" ", leftPadding) + t.ToPrint + strings.Repeat(" ", rightPadding))
 	case Left:
-		padding := t.maxTextLength - t.TextLen
+		padding := t.maxTextLength - t.Len()
 		b.WriteString(t.ToPrint + strings.Repeat(" ", padding))
 	case Right:
-		padding := t.maxTextLength - t.TextLen
+		padding := t.maxTextLength - t.Len()
 		b.WriteString(strings.Repeat(" ", padding) + t.ToPrint)
 	default:
 		panic("unknown Alignment: " + t.Alignment.String())

--- a/utils/siphon/siphon.go
+++ b/utils/siphon/siphon.go
@@ -1,6 +1,6 @@
 // Use of this source code is governed by a GPL-2 license that can be found in the LICENSE file.
 //
-// Copyright 2024 Lexer747
+// Copyright 2024-2025 Lexer747
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
@@ -12,7 +12,7 @@ import (
 
 // TeeBufferedChannel, duplicates the channel such that both returned channels receive values from [c], this
 // duplication is unsynchronised. Both channels are closed when the [ctx] is done.
-func TeeBufferedChannel[T any](ctx context.Context, c chan T, channelSize int) (
+func TeeBufferedChannel[T any](ctx context.Context, c <-chan T, channelSize int) (
 	chan T,
 	chan T,
 ) {


### PR DESCRIPTION
Graph control:

* New `graph.Control` type, which will be extended in future, serving as a signaller of control flow from the GUI to the textual presentation. 
* Tweak the `graph/graphdata/graphdata.go` iterator to work in this new follow mode, in which a fixed offset is used, and only one overall span to get data and stats from.

Misc:

* New `graph.GraphConfiguration` instead of a large parameter pack for the graph constructions
* Add channel direction safety where it's obvious.
* Refactor X and Y axis into new files.
* Better document the GUI abstractions.
* Loosely try other IP methods before failing (was attempting to support windows but doesn't work yet).
* Add a traceprofile output (no obvious gains ATM).