### PR TITLE
Windows API fixes

### DIFF
--- a/ping/addr.go
+++ b/ping/addr.go
@@ -1,0 +1,44 @@
+// Use of this source code is governed by a GPL-2 license that can be found in the LICENSE file.
+//
+// Copyright 2025 Lexer747
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ping
+
+import "net"
+
+type addr struct {
+	ip net.IP
+
+	asUDP *net.UDPAddr
+	asIP  *net.IPAddr
+}
+
+func New(addrType addressType, ip net.IP) *addr {
+	// TODO Port?
+	switch addrType {
+	case _IP4, _IP6:
+		return &addr{ip: ip, asIP: &net.IPAddr{IP: ip}}
+	case _UDP4, _UDP6:
+		return &addr{ip: ip, asUDP: &net.UDPAddr{IP: ip, Port: 0}}
+	default:
+		return nil
+	}
+}
+
+func (a *addr) Get() net.Addr {
+	if a.asUDP != nil {
+		return a.asUDP
+	} else {
+		return a.asIP
+	}
+}
+
+func (a *addr) String() string {
+	return a.ip.String()
+}
+
+func (a *addr) Equal(IP net.IP) bool {
+	return a.ip.Equal(IP)
+}

--- a/ping/utils.go
+++ b/ping/utils.go
@@ -1,0 +1,54 @@
+// Use of this source code is governed by a GPL-2 license that can be found in the LICENSE file.
+//
+// Copyright 2024-2025 Lexer747
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ping
+
+import "net"
+
+const _IPv4len = 4
+const _IPv6len = 16
+
+func isIpv4(ip net.IP) bool {
+	isZeros := func(p net.IP) bool {
+		for i := range p {
+			if p[i] != 0 {
+				return false
+			}
+		}
+		return true
+	}
+	if len(ip) == _IPv4len {
+		return true
+	}
+	if len(ip) == _IPv6len &&
+		isZeros(ip[0:10]) &&
+		ip[10] == 0xff &&
+		ip[11] == 0xff {
+		return true
+	}
+	return false
+}
+
+func isIpv6(ip net.IP) bool {
+	isZeros := func(p net.IP) bool {
+		for i := range p {
+			if p[i] != 0 {
+				return false
+			}
+		}
+		return true
+	}
+	if len(ip) == _IPv4len {
+		return false
+	}
+	if len(ip) == _IPv6len &&
+		isZeros(ip[0:10]) &&
+		ip[10] == 0xff &&
+		ip[11] == 0xff {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Quick timeline:

* Pre- 199c5cd01c4e7dead4febd02b373a876bd781dd1 when running `acci-ping` on my windows 11 machine it would fail with:
  ```
  > go run .\acci-ping.go ping
  Couldn't start ping channel: couldn't listen caused by: socket: The requested protocol has not been configured into the system, or no implementation for it exists.exit status 1
  ```
* in 199c5cd01c4e7dead4febd02b373a876bd781dd1 I tweaked the socket connector to try more than one connection strategy with the underlying OS:
  ```go
  var listenList = []listenerConfig{
  	{network: "udp4", address: ipv4ListenAddr.String()},
  	{network: "udp6", address: ipv6ListenAddr.String()},
  	{network: "ip4:1", address: ipv4ListenAddr.String()},
  	{network: "ip6:ipv6-icmp", address: ipv6ListenAddr.String()},
  
  	// TODO add and support:
  	//	- ip4:icmp
  	//	- ip6:58
  	//	- udp4 + custom addr
  	//	- udp6 + custom addr
  }
  ```
  This now succeeds and windows actually lets us create an unprivileged socket. But would then silently fail with 0ms pings:
  ```
  > go run .\acci-ping.go ping
  Pinging to "www.google.com" (4 times) at "142.250.187.196"
  142.250.187.196 | 2025-04-21T14:32:47.3394548+01:00 | 0s
  142.250.187.196 | 2025-04-21T14:32:48.6728044+01:00 | 0s
  142.250.187.196 | 2025-04-21T14:32:50.005742+01:00 | 0s
  142.250.187.196 | 2025-04-21T14:32:51.3385608+01:00 | 0s
  ```
* During this patch I fixed the string representation to actually reveal the internal error which was:
  ```
  Internal Error 2025-04-21T12:50:28.2525228+01:00 reason couldn't write packet to connection "www.google.com" caused by: write ip4 0.0.0.0->142.250.180.4:0: invalid argument
  ```
  This is happening due to my rush in 199c5cd01c4e7dead4febd02b373a876bd781dd1 in which I didn't actually propagate the underlying socket change to all parts of the ping api. Here we were casting the `net.IP` to a `net.UDPAddr` but we had an underlying `ipv4:1` socket, so we need to cast the ip to a `net.IPAddr`. 

Therefore this patch has a new `ping/addr.go` type which wraps the `net.IP` in a simple struct and instead we store this new type in the DNS cache forwarding the socket type when we construct an addr.

Now when I run this one windows it actually works :)

```
> cmd /c ver

Microsoft Windows [Version 10.0.26100.3775]
> go run .\acci-ping.go ping
Pinging to "www.google.com" (4 times) at "216.58.201.100"
216.58.201.100 | 2025-04-21T14:25:17.8497833+01:00 | 9.5325ms
216.58.201.100 | 2025-04-21T14:25:19.183305+01:00 | 8.5728ms
216.58.201.100 | 2025-04-21T14:25:20.5159929+01:00 | 8.6068ms
216.58.201.100 | 2025-04-21T14:25:21.8492549+01:00 | 8.5085ms
```

Note I have still haven't testing the graphing and this will come later, for now I'm just ensuring the underlying API works.