### PR TITLE
Fix DNS Retrying Logic

### DIFF
--- a/acci-ping.go
+++ b/acci-ping.go
@@ -23,7 +23,8 @@ import (
 	"github.com/Lexer747/acci-ping/utils/exit"
 )
 
-// these looking more bash variables helps clue me into where these actually come from which is build time linking, see tools/build.sh.
+// these looking more bash variables helps clue me into where these
+// actually come from which is build time linking, see tools/build.sh.
 //
 //nolint:staticcheck
 var (

--- a/cmd/subcommands/rawdata/rawdata.go
+++ b/cmd/subcommands/rawdata/rawdata.go
@@ -28,7 +28,7 @@ func GetFlags() *Config {
 	f := flag.NewFlagSet("", flag.ContinueOnError)
 	ret := &Config{
 		FlagSet:  f,
-		printAll: f.Bool("all", true, "prints all raw values otherwise only summarises '.pings' files"),
+		printAll: f.Bool("all", false, "prints all raw values otherwise only summarises '.pings' files"),
 		toCSV:    f.Bool("csv", false, "writes '.pings' files as '.csv'"),
 	}
 
@@ -79,7 +79,7 @@ func handle(printAll, toCSV bool, d *data.Data) {
 	case toCSV:
 		handleCSV(d)
 	default:
-		fmt.Fprintln(os.Stdout, d.String())
+		fmt.Fprintln(os.Stdout, d.Summary())
 	}
 }
 

--- a/graph/data/data.go
+++ b/graph/data/data.go
@@ -104,6 +104,10 @@ func (d *Data) String() string {
 	return fmt.Sprintf("%s: PingsMeta#%d [%s] | %s | %s", d.URL, d.PingsMeta, d.Network.String(), d.Header.String(), d.Runs.String())
 }
 
+func (d *Data) Summary() string {
+	return fmt.Sprintf("%s: PingsMeta#%d [%s] | %s | %s", d.URL, d.PingsMeta, d.Network.String(), d.Header.Summary(), d.Runs.String())
+}
+
 func (d *Data) In(tz *time.Location) *Data {
 	ret := newVersionedData(d.URL, d.PingsMeta)
 	for i := range d.TotalCount {
@@ -234,6 +238,12 @@ func (h *Header) AddPoint(p ping.PingDataPoint) {
 func (h *Header) String() string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s | %s", h.TimeSpan.String(), h.Stats.String())
+	return b.String()
+}
+
+func (h *Header) Summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s | %s", h.TimeSpan.String(), h.Stats.PickString(math.MaxInt))
 	return b.String()
 }
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -151,6 +151,7 @@ func (g *Graph) Run(
 	graph := func() error {
 		size := g.Term.GetSize()
 		defer close(terminalUpdates)
+		slog.Debug("running acci-ping")
 		for {
 			select {
 			case <-ctx.Done():
@@ -213,11 +214,11 @@ func (g *Graph) LastFrame() string {
 	return b.String()
 }
 
-// Summarise will summarise the graph's backed data according to the [*graphdata.GraphData.String] function.
+// Summarise will summarise the graph's backed data according to the [*graphdata.GraphData.Summary] function.
 func (g *Graph) Summarise() string {
 	g.frameMutex.Lock()
 	defer g.frameMutex.Unlock()
-	return strings.ReplaceAll(g.data.String(), "| ", "\n\t")
+	return strings.ReplaceAll(g.data.Summary(), "| ", "\n\t")
 }
 
 func (g *Graph) sink(ctx context.Context) {
@@ -228,7 +229,7 @@ func (g *Graph) sink(ctx context.Context) {
 			return
 		case p, ok := <-g.dataChannel:
 			// TODO configure logging channels
-			// slog.Debug("graph sink data received", "packet", p)
+			slog.Debug("graph sink, data received", "packet", p)
 			if !ok {
 				g.sinkAlive = false
 				return

--- a/graph/graphdata/graphdata.go
+++ b/graph/graphdata/graphdata.go
@@ -70,6 +70,12 @@ func (gd *GraphData) String() string {
 	return gd.data.String()
 }
 
+func (gd *GraphData) Summary() string {
+	gd.Lock()
+	defer gd.Unlock()
+	return gd.data.Summary()
+}
+
 func (gd *GraphData) AsCompact(w io.Writer) error {
 	gd.m.Lock()
 	defer gd.m.Unlock()

--- a/ping/api_implementation.go
+++ b/ping/api_implementation.go
@@ -66,7 +66,7 @@ func (p *Ping) startChannel(ctx context.Context, client chan<- PingResults, clos
 }
 
 func (p *Ping) buildRateLimiting(pingsPerMinute float64) *time.Ticker {
-	p.timeout = time.Second
+	p.timeout = 500 * time.Millisecond
 	var rateLimit *time.Ticker
 	// Zero is the sentinel, go as fast as possible
 	if pingsPerMinute != 0 {


### PR DESCRIPTION
Turns out I didn't quite implement that loop right, I finally ran into my DNS cache being used as some IPs were being rotated. Furthermore this patch adds a timeout to DNS queries in general.

Also fixes some presentation bugs.