### PR TITLE
Tab Autocomplete

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "cSpell.words": [
-    ]
-}

--- a/cmd/subcommands/acci-ping/acci-ping.go
+++ b/cmd/subcommands/acci-ping/acci-ping.go
@@ -11,6 +11,7 @@ import (
 	"flag"
 	"strings"
 
+	"github.com/Lexer747/acci-ping/cmd/tab_completion/tabflags"
 	"github.com/Lexer747/acci-ping/graph"
 	"github.com/Lexer747/acci-ping/gui/themes"
 	"github.com/Lexer747/acci-ping/terminal"
@@ -24,7 +25,7 @@ import (
 type Config struct {
 	*application.BuildInfo
 	*application.SharedFlags
-	*flag.FlagSet
+	*tabflags.FlagSet
 
 	debugFps           *int
 	debuggingTermSize  *string
@@ -41,31 +42,35 @@ type Config struct {
 
 func GetFlags(info *application.BuildInfo) *Config {
 	f := flag.NewFlagSet("", flag.ContinueOnError)
-	sf := application.NewSharedFlags(f)
+	tf := tabflags.NewAutoCompleteFlagSet(f, false, "")
+	sf := application.NewSharedFlags(tf)
 	ret := &Config{
 		BuildInfo:   info,
 		SharedFlags: sf,
-		FlagSet:     f,
+		FlagSet:     tf,
 
-		filePath:           f.String("file", "", "the file to write the pings into. (default data not saved)"),
-		hideHelpOnStart:    f.Bool("hide-help", false, "if this flag is used the help box will be hidden by default"),
+		filePath: tf.String("file", "", "the file to write the pings into. (default data not saved)",
+			tabflags.AutoComplete{WantsFile: true, FileExt: ".pings"}),
+		hideHelpOnStart:    tf.Bool("hide-help", false, "if this flag is used the help box will be hidden by default"),
 		pingBufferingLimit: new(int),
-		pingsPerMinute: f.Float64("pings-per-minute", 60.0,
+		pingsPerMinute: tf.Float64("pings-per-minute", 60.0,
 			"sets the speed at which the program will try to get new ping results, 0 represents no limit.\n"+
 				"Negative values are an error."),
-		testErrorListener: f.Bool("debug-error-creator", false,
+		testErrorListener: tf.Bool("debug-error-creator", false,
 			"binds the ["+ansi.Blue("e")+"] key to create errors for GUI verification"),
-		url: f.String("url", "www.google.com", "the url to target for ping testing"),
-		theme: f.String("theme", "", "the colour theme (either a path or builtin theme name) to use for the program,\n"+
+		url: tf.String("url", "www.google.com", "the url to target for ping testing", tabflags.AutoComplete{}),
+		theme: tf.String("theme", "", "the colour theme (either a path or builtin theme name) to use for the program,\n"+
 			"if empty this will try to get the background colour of the terminal and pick the\n"+
 			"built in dark or light theme based on the colour found.\n"+
 			"There's also the builtin themes:\n"+strings.Join(themes.DescribeBuiltins(), "\n")+
 			"\nSee the docs "+ansi.Blue("https://github.com/Lexer747/acci-ping/blob/main/docs/themes.md")+
-			" for how to create custom themes."),
-		debuggingTermSize:  f.String("debug-term-size", "", "switches the terminal to fixed mode and no iteractivity"),
-		followingOnStart:   f.Bool("follow", false, "if this flag is used the graph will be shown in following mode immediately"),
-		debugFps:           f.Int("debug-fps", 240, "configures the internal tickrate for the graph re-paint look (in FPS)"),
-		logarithmicOnStart: f.Bool("logarithmic", false, "if this flag is used the graph will be shown in logarithmic mode immediately"),
+			" for how to create custom themes.",
+			tabflags.AutoComplete{Choices: themes.GetBuiltInNames(), WantsFile: true, FileExt: ".json"}),
+		debuggingTermSize: tf.String("debug-term-size", "", "switches the terminal to fixed mode and no iteractivity",
+			tabflags.AutoComplete{Choices: []string{"15x80", "20x85", "HxW"}}),
+		followingOnStart:   tf.Bool("follow", false, "if this flag is used the graph will be shown in following mode immediately"),
+		debugFps:           tf.Int("debug-fps", 240, "configures the internal tickrate for the graph re-paint look (in FPS)"),
+		logarithmicOnStart: tf.Bool("logarithmic", false, "if this flag is used the graph will be shown in logarithmic mode immediately"),
 	}
 	*ret.pingBufferingLimit = 10
 	return ret

--- a/cmd/subcommands/ping/ping.go
+++ b/cmd/subcommands/ping/ping.go
@@ -11,13 +11,14 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/Lexer747/acci-ping/cmd/tab_completion/tabflags"
 	"github.com/Lexer747/acci-ping/ping"
 	"github.com/Lexer747/acci-ping/utils/check"
 	"github.com/Lexer747/acci-ping/utils/exit"
 )
 
 type Config struct {
-	*flag.FlagSet
+	*tabflags.FlagSet
 
 	url   *string
 	count *int
@@ -25,10 +26,11 @@ type Config struct {
 
 func GetFlags() *Config {
 	f := flag.NewFlagSet("", flag.ContinueOnError)
+	tf := tabflags.NewAutoCompleteFlagSet(f, false, "")
 	ret := &Config{
-		url:     f.String("url", "www.google.com", "the url to target for ping testing"),
-		count:   f.Int("n", 4, "the number of packets to send. 0 or smaller means continuous running."),
-		FlagSet: f,
+		url:     tf.String("url", "www.google.com", "the url to target for ping testing", tabflags.AutoComplete{}),
+		count:   tf.Int("n", 4, "the number of packets to send. 0 or smaller means continuous running."),
+		FlagSet: tf,
 	}
 	return ret
 }

--- a/cmd/subcommands/rawdata/rawdata.go
+++ b/cmd/subcommands/rawdata/rawdata.go
@@ -12,13 +12,14 @@ import (
 	"os"
 	"time"
 
+	"github.com/Lexer747/acci-ping/cmd/tab_completion/tabflags"
 	"github.com/Lexer747/acci-ping/graph/data"
 	"github.com/Lexer747/acci-ping/utils/check"
 	"github.com/Lexer747/acci-ping/utils/exit"
 )
 
 type Config struct {
-	*flag.FlagSet
+	*tabflags.FlagSet
 
 	printAll *bool
 	toCSV    *bool
@@ -26,10 +27,11 @@ type Config struct {
 
 func GetFlags() *Config {
 	f := flag.NewFlagSet("", flag.ContinueOnError)
+	tf := tabflags.NewAutoCompleteFlagSet(f, true, ".pings")
 	ret := &Config{
-		FlagSet:  f,
-		printAll: f.Bool("all", false, "prints all raw values otherwise only summarises '.pings' files"),
-		toCSV:    f.Bool("csv", false, "writes '.pings' files as '.csv'"),
+		FlagSet:  tf,
+		printAll: tf.Bool("all", false, "prints all raw values otherwise only summarises '.pings' files"),
+		toCSV:    tf.Bool("csv", false, "writes '.pings' files as '.csv'"),
 	}
 
 	f.Usage = func() {

--- a/cmd/subcommands/version/version.go
+++ b/cmd/subcommands/version/version.go
@@ -11,20 +11,22 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Lexer747/acci-ping/cmd/tab_completion/tabflags"
 	"github.com/Lexer747/acci-ping/terminal/ansi"
 	"github.com/Lexer747/acci-ping/utils/application"
 )
 
 type Config struct {
 	*application.BuildInfo
-	*flag.FlagSet
+	*tabflags.FlagSet
 }
 
 func GetFlags(info *application.BuildInfo) *Config {
 	f := flag.NewFlagSet("", flag.ContinueOnError)
+	tf := tabflags.NewAutoCompleteFlagSet(f, false, "")
 	ret := &Config{
 		BuildInfo: info,
-		FlagSet:   f,
+		FlagSet:   tf,
 	}
 	return ret
 }

--- a/cmd/tab_completion/acci-ping
+++ b/cmd/tab_completion/acci-ping
@@ -1,0 +1,12 @@
+_acci-ping()
+{
+    # $COMP_WORDS # an array of all the words typed after the name of the program the compspec belongs to
+    # $COMP_CWORD # an index of the COMP_WORDS array pointing to the word the current cursor is at - in other words, the index of the word the cursor was when the tab key was pressed
+    # $COMP_LINE # the current command line
+
+    local reply
+    reply=$(acci-ping b2827fc8fc8c8267cb15f5a925de7e4712aa04ef2fbd43458326b595d66a36d9 "$COMP_CWORD" b2827fc8fc8c8267cb15f5a925de7e4712aa04ef2fbd43458326b595d66a36d9 "${COMP_WORDS[*]}" b2827fc8fc8c8267cb15f5a925de7e4712aa04ef2fbd43458326b595d66a36d9 "$COMP_LINE")
+    IFS=" " read -r -a COMPREPLY <<< "$reply"
+}
+complete -F _acci-ping acci-ping
+# sudo cp ./cmd/tab-completion/acci-ping /etc/bash_completion.d/acci-ping && source ~/.bashrc

--- a/cmd/tab_completion/tab_completion.go
+++ b/cmd/tab_completion/tab_completion.go
@@ -1,0 +1,273 @@
+// Use of this source code is governed by a GPL-2 license that can be found in the LICENSE file.
+//
+// Copyright 2025 Lexer747
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+//nolint:staticcheck
+package tabcompletion
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/Lexer747/acci-ping/cmd/tab_completion/tabflags"
+	"github.com/Lexer747/acci-ping/utils/check"
+	"github.com/Lexer747/acci-ping/utils/errors"
+	"github.com/Lexer747/acci-ping/utils/exit"
+	"github.com/Lexer747/acci-ping/utils/sliceutils"
+)
+
+const debug = true
+
+const AutoCompleteString = "b2827fc8fc8c8267cb15f5a925de7e4712aa04ef2fbd43458326b595d66a36d9" // sha256 of `autoCompleteString`
+
+type Command struct {
+	Cmd string
+	Fs  *tabflags.FlagSet
+}
+
+// Run will for a given command line input, write to stdout the autocomplete suggestion for the input [base]
+// and subcommands.
+func Run(args []string, base Command, subCommands []Command) {
+	if debug {
+		cleanup := makeLogFile()
+		defer cleanup()
+	} else {
+		h := slog.DiscardHandler
+		slog.SetDefault(slog.New(h))
+	}
+	// Catch panic's in the case of a mistake in this algorithm simply return no autocomplete suggestions.
+	defer func() {
+		if err := recover(); err != nil {
+			slog.Error("caught panic", "err", err)
+			tabExitFailure()
+		}
+	}()
+	slog.Debug("auto complete called with", "args", args)
+
+	// The format of tab completion is quite simple, bash expects the called program (in this case this
+	// program) to return a space separated list of possible continuations. How this list is constructed is up
+	// to the program.
+
+	// The available args to this program are agreed by the stub script provided by this repo:
+	// cmd/tab-completion/acci-ping, if these are not provided this sub command won't be called and no auto
+	// completion provided.
+
+	args = args[2:] // the first arg will always be the program name, second arg the auto-complete string
+
+	// reslice back to the original inputs
+	_COMP_CWORD, _COMP_LINE, _COMP_WORDS := parseCOMP(args)
+
+	index, err := strconv.Atoi(_COMP_CWORD)
+	if err != nil {
+		tabExitFailure()
+	}
+
+	slog.Debug("inputs", "index", index, "_COMP_CWORD", _COMP_CWORD, "_COMP_LINE", _COMP_LINE, "_COMP_WORDS", _COMP_WORDS)
+	choices, err := getChoices(index, _COMP_LINE, base, subCommands)
+	slog.Debug("results", "choices", choices, "err", err)
+	if err != nil {
+		tabExitFailure()
+		return
+	}
+	tabExit(choices)
+}
+
+// getChoices is the workhorse of autocomplete, it's more functional in style in that it should not output
+// anything to stdout and instead returns the slice of autocomplete suggestions or error if something went
+// wrong. Note that it can have side effects if an autocomplete wants a file as input to it's flag and
+// therefore may read the current files in the working dir.
+func getChoices(index int, _COMP_LINE []string, base Command, cmds []Command) ([]string, error) {
+	slog.Debug("info", "len(_COMP_LINE)", len(_COMP_LINE))
+	if index == 1 && len(_COMP_LINE) <= 1 {
+		// Edge case, when we have exactly one index we should follow up with all the flags for the "base" command
+		// as well as the names of the subcommands.
+		return flagsAndSubcommands(cmds, getFlag(base.Fs.FlagSet)), nil
+	}
+	if index == 1 {
+		// Edge case, same as above but there is some starting words being entered by the user so use that to
+		// restrict the output
+		return flagsAndSubcommandsWithPrefix(index, _COMP_LINE, cmds, getFlag(base.Fs.FlagSet)), nil
+	}
+	if index > 1 {
+		// determine if we have a subcommand selected or are embracing the base and selecting flags
+		isBase := strings.HasPrefix(_COMP_LINE[1], "-")
+		var flags *tabflags.FlagSet
+		var wantsFile bool
+		var curCommand, fileExt string
+		if isBase {
+			flags = base.Fs
+			wantsFile = base.Fs.WantsFile()
+			curCommand = base.Cmd
+			fileExt = base.Fs.FileExt()
+		} else {
+			sub := _COMP_LINE[1]
+			choice := sliceutils.Filter(cmds, func(sc Command) bool { return sc.Cmd == sub })
+			if len(choice) != 1 {
+				return nil, errors.Errorf("No sub command found for %q", sub)
+			}
+			cmd := choice[0]
+			flags = cmd.Fs
+			wantsFile = cmd.Fs.WantsFile()
+			curCommand = cmd.Cmd
+			fileExt = cmd.Fs.FileExt()
+		}
+		cur := _COMP_LINE[len(_COMP_LINE)-1]
+		return suggestionAutoComplete(index, _COMP_LINE, flags, wantsFile, fileExt, cur, curCommand), nil
+	}
+	slog.Error("unable to solve")
+	return nil, errors.Errorf("unexpected inputs")
+}
+
+func suggestionAutoComplete(
+	index int,
+	_COMP_LINE []string,
+	flags *tabflags.FlagSet,
+	wantsFile bool,
+	fileExt, cur, curCommand string,
+) []string {
+	alreadySet := _COMP_LINE[1:index]
+	var files []string
+	if wantsFile {
+		files = getWorkingDirFiles()
+		if fileExt != "" {
+			files = sliceutils.Filter(files, func(path string) bool { return filepath.Ext(path) == fileExt })
+		}
+	}
+
+	prev := _COMP_LINE[index-1]
+	ac := flags.GetAutoCompleteFor(prev)
+	if ac == nil {
+		includeDebug := strings.HasPrefix(cur, "-d")
+		names := flags.GetNames(includeDebug, alreadySet)
+		return filterByPrefix(slices.Concat(names, files), cur)
+	}
+
+	// suggest continuation
+	if prev == curCommand {
+		return returnFlagSetNames(cur, flags, files, alreadySet)
+	}
+	toSuggest := *ac
+	if toSuggest.WantsFile {
+		files = getWorkingDirFiles()
+		if toSuggest.FileExt != "" {
+			files = sliceutils.Filter(files, func(path string) bool { return filepath.Ext(path) == toSuggest.FileExt })
+		}
+	}
+	if len(toSuggest.Choices) == 0 {
+		return returnFlagSetNames(cur, flags, files, alreadySet)
+	}
+	return filterByPrefix(slices.Concat(toSuggest.Choices, files), cur)
+}
+
+func getWorkingDirFiles() (files []string) {
+	f, err := os.Open("./")
+	if err != nil {
+		slog.Error("failed to get files", "err", err)
+	}
+	files, err = f.Readdirnames(0)
+	if err != nil {
+		slog.Error("failed to get files", "err", err)
+	}
+	err = f.Close()
+	if err != nil {
+		slog.Error("failed to close dir", "err", err)
+	}
+	return files
+}
+
+func returnFlagSetNames(cur string, flags *tabflags.FlagSet, files, alreadySet []string) []string {
+	includeDebug := strings.HasPrefix(cur, "-d")
+	names := flags.GetNames(includeDebug, alreadySet)
+	return filterByPrefix(slices.Concat(names, files), cur)
+}
+
+func flagsAndSubcommands(cmds []Command, flags []string) []string {
+	subCommandNames := sliceutils.Map(cmds, func(s Command) string { return s.Cmd })
+	return slices.Concat(subCommandNames, removeByPrefix(flags, "-debug"))
+}
+
+func flagsAndSubcommandsWithPrefix(index int, _COMP_LINE []string, cmds []Command, flags []string) []string {
+	prefix := _COMP_LINE[index]
+	includeDebug := strings.HasPrefix(prefix, "-d")
+	subCommandNames := sliceutils.Map(cmds, func(s Command) string { return s.Cmd })
+	if !includeDebug {
+		flags = removeByPrefix(flags, "-debug")
+	}
+	toSearch := slices.Concat(subCommandNames, flags)
+	return filterByPrefix(toSearch, prefix)
+}
+
+func filterByPrefix(options []string, prefix string) []string {
+	return sliceutils.Filter(options, func(s string) bool { return strings.HasPrefix(s, prefix) })
+}
+
+func removeByPrefix(options []string, prefix string) []string {
+	return sliceutils.Filter(options, func(s string) bool { return !strings.HasPrefix(s, prefix) })
+}
+
+func getFlag(fs *flag.FlagSet) []string {
+	var result []string
+	fs.VisitAll(func(f *flag.Flag) {
+		result = append(result, "-"+f.Name)
+	})
+	return result
+}
+
+// parseCOMP relies on the assumption that the input from the arguments to this function has been formed by
+// cmd/tab_completion/acci-ping, which is placed in the /etc/bash_completion.d/acci-ping or whatever shell the
+// user is using.
+func parseCOMP(args []string) (_COMP_CWORD string, _COMP_LINE []string, _COMP_WORDS []string) {
+	state := 0
+	prev := 0
+	// Do a single linear search, each new [AutoCompleteString] will be separating each of the normal
+	// arguments.
+	for i, arg := range args {
+		if arg == AutoCompleteString && state == 0 {
+			_COMP_CWORD = args[prev:i][0]
+			state = 1
+			prev = i
+		}
+		if arg == AutoCompleteString && state == 1 {
+			_COMP_WORDS = args[prev:i]
+			state = 2
+		}
+		if arg == AutoCompleteString && state == 2 {
+			_COMP_LINE = args[i+1:]
+			if len(_COMP_LINE) == 1 {
+				_COMP_LINE = strings.Split(_COMP_LINE[0], " ")
+			}
+		}
+	}
+	return _COMP_CWORD, _COMP_LINE, _COMP_WORDS
+}
+
+func tabExit(results []string) {
+	fmt.Fprint(os.Stdout, strings.Join(results, " "))
+	exit.Success()
+}
+func tabExitFailure() {
+	tabExit([]string{})
+}
+
+func makeLogFile() (toDefer func()) {
+	f, err := os.Create("/home/lexer747/repos/acci-ping/testing.log")
+	check.NoErr(err, "could not create Log file")
+	h := slog.NewTextHandler(f, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+	logger := slog.New(h)
+	slog.SetDefault(logger)
+	slog.Debug("Logging started")
+	return func() {
+		slog.Debug("Logging finished, closing")
+		check.NoErr(f.Close(), "failed to close log file")
+	}
+}

--- a/cmd/tab_completion/tab_completion_test.go
+++ b/cmd/tab_completion/tab_completion_test.go
@@ -1,0 +1,252 @@
+// Use of this source code is governed by a GPL-2 license that can be found in the LICENSE file.
+//
+// Copyright 2025 Lexer747
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+//nolint:testpackage
+package tabcompletion
+
+import (
+	"flag"
+	"log"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Lexer747/acci-ping/cmd/subcommands/drawframe"
+	"github.com/Lexer747/acci-ping/cmd/tab_completion/tabflags"
+	"github.com/Lexer747/acci-ping/gui/themes"
+	"github.com/Lexer747/acci-ping/utils/application"
+	"github.com/Lexer747/acci-ping/utils/sliceutils"
+	"gotest.tools/v3/assert"
+)
+
+var accipingFlags = make_acciping_Flags()
+var subCommands = []Command{
+	make_drawframe_Flags(),
+	make_version_Flags(),
+}
+
+func TestGetChoices(t *testing.T) {
+	t.Parallel()
+	t.Run("tab", func(t *testing.T) {
+		t.Parallel()
+		actual, err := runGetChoices("acci-ping")
+		assert.NilError(t, err)
+
+		expectedFlags := []string{}
+		accipingFlags.Fs.VisitAll(func(f *flag.Flag) {
+			if strings.HasPrefix(f.Name, "debug") {
+				return
+			}
+			expectedFlags = append(expectedFlags, "-"+f.Name)
+		})
+
+		assertEqual(t, actual, slices.Concat([]string{"drawframe", "version"}, expectedFlags))
+	})
+	t.Run("start drawframe", func(t *testing.T) {
+		t.Parallel()
+		actual, err := runGetChoices("acci-ping", "d")
+		assert.NilError(t, err)
+		assertEqual(t, actual, []string{"drawframe"})
+	})
+	t.Run("start drawframe 2", func(t *testing.T) {
+		t.Parallel()
+		actual, err := runGetChoices("acci-ping", "draw")
+		assert.NilError(t, err)
+		assertEqual(t, actual, []string{"drawframe"})
+	})
+	t.Run("start version", func(t *testing.T) {
+		t.Parallel()
+		actual, err := runGetChoices("acci-ping", "v")
+		assert.NilError(t, err)
+		assertEqual(t, actual, []string{"version"})
+	})
+	t.Run("start -", func(t *testing.T) {
+		t.Parallel()
+		actual, err := runGetChoices("acci-ping", "-")
+		assert.NilError(t, err)
+
+		expectedFlags := []string{}
+		accipingFlags.Fs.VisitAll(func(f *flag.Flag) {
+			if strings.HasPrefix(f.Name, "debug") {
+				return
+			}
+			expectedFlags = append(expectedFlags, "-"+f.Name)
+		})
+		assertEqual(t, actual, expectedFlags)
+	})
+	t.Run("start drawframe ", func(t *testing.T) {
+		t.Parallel()
+		actual, err := runGetChoices("acci-ping", "drawframe", "")
+		assert.NilError(t, err)
+
+		expectedFlags := []string{}
+		drawframe.GetFlags(nil).VisitAll(func(f *flag.Flag) {
+			if strings.HasPrefix(f.Name, "debug") {
+				return
+			}
+			expectedFlags = append(expectedFlags, "-"+f.Name)
+		})
+		expectedFlags = slices.Concat(expectedFlags, filesByExt(".go"))
+		assertEqual(t, actual, expectedFlags)
+	})
+	t.Run("start drawframe -t", func(t *testing.T) {
+		t.Parallel()
+		actual, err := runGetChoices("acci-ping", "drawframe", "-t")
+		assert.NilError(t, err)
+
+		expectedFlags := []string{}
+		drawframe.GetFlags(nil).VisitAll(func(f *flag.Flag) {
+			if !strings.HasPrefix(f.Name, "t") {
+				return
+			}
+			expectedFlags = append(expectedFlags, "-"+f.Name)
+		})
+		assert.DeepEqual(t, actual, expectedFlags)
+	})
+	t.Run("start <random>", func(t *testing.T) {
+		t.Parallel()
+		starting := []string{}
+		accipingFlags.Fs.VisitAll(func(f *flag.Flag) {
+			if strings.HasPrefix(f.Name, "debug") {
+				return
+			}
+			starting = append(starting, "-"+f.Name)
+		})
+		start := sliceutils.TakeRandom(starting)
+		expectedFlags := sliceutils.Remove(starting, start)
+
+		actual, err := runGetChoices("acci-ping", start, "")
+		assert.NilError(t, err)
+		assertEqual(t, actual, expectedFlags)
+	})
+	t.Run("start -file", func(t *testing.T) {
+		t.Parallel()
+		expectedFlags := []string{}
+		accipingFlags.Fs.VisitAll(func(f *flag.Flag) {
+			if strings.HasPrefix(f.Name, "debug") || f.Name == "file" {
+				return
+			}
+			expectedFlags = append(expectedFlags, "-"+f.Name)
+		})
+		expectedFlags = slices.Concat(expectedFlags, filesByExt(".go"))
+
+		actual, err := runGetChoices("acci-ping", "-file", "")
+		assert.NilError(t, err)
+
+		assertEqual(t, actual, expectedFlags)
+	})
+	t.Run("start -file foobar.txt <random>", func(t *testing.T) {
+		t.Parallel()
+		starting := []string{}
+		accipingFlags.Fs.VisitAll(func(f *flag.Flag) {
+			if strings.HasPrefix(f.Name, "debug") {
+				return
+			}
+			starting = append(starting, "-"+f.Name)
+		})
+		randomChoices := []string{}
+		accipingFlags.Fs.VisitAll(func(f *flag.Flag) {
+			_, ok := f.Value.(boolFlag)
+			if strings.HasPrefix(f.Name, "debug") || !ok {
+				return
+			}
+			randomChoices = append(randomChoices, "-"+f.Name)
+		})
+		start := sliceutils.TakeRandom(randomChoices)
+		expectedFlags := sliceutils.Remove(starting, start, "-file")
+
+		actual, err := runGetChoices("acci-ping", "-file", "foobar.txt", start, "")
+		assert.NilError(t, err)
+
+		assertEqual(t, actual, expectedFlags)
+	})
+	t.Run("start -theme", func(t *testing.T) {
+		t.Parallel()
+		expectedFlags := slices.Concat(themes.GetBuiltInNames(), filesByExt(""))
+
+		actual, err := runGetChoices("acci-ping", "-theme", "")
+		assert.NilError(t, err)
+
+		assertEqual(t, actual, expectedFlags)
+	})
+	t.Run("start -theme c", func(t *testing.T) {
+		t.Parallel()
+		expectedFlags := slices.Concat(themes.GetBuiltInNames(), filesByExt(""))
+		expectedFlags = sliceutils.Filter(expectedFlags, func(s string) bool { return strings.HasPrefix(s, "c") })
+
+		actual, err := runGetChoices("acci-ping", "-theme", "c")
+		assert.NilError(t, err)
+
+		assertEqual(t, actual, expectedFlags)
+	})
+}
+
+func runGetChoices(args ...string) ([]string, error) {
+	return getChoices(max(1, len(args)-1), args, accipingFlags, subCommands)
+}
+
+type boolFlag interface {
+	flag.Value
+	IsBoolFlag() bool
+}
+
+//nolint:staticcheck
+func make_acciping_Flags() Command {
+	f := flag.NewFlagSet("", flag.ContinueOnError)
+	tf := tabflags.NewAutoCompleteFlagSet(f, false, "")
+	_ = application.NewSharedFlags(tf)
+
+	_ = tf.String("file", "", "skipped for test",
+		tabflags.AutoComplete{WantsFile: true, FileExt: ".go"})
+	_ = tf.Bool("hide-help", false, "skipped for test")
+	_ = tf.Float64("pings-per-minute", 60.0, "skipped for test")
+	_ = tf.Bool("debug-error-creator", false, "skipped for test")
+	_ = tf.String("url", "www.google.com", "skipped for test", tabflags.AutoComplete{})
+	_ = tf.String("theme", "", "skipped for test",
+		tabflags.AutoComplete{Choices: themes.GetBuiltInNames(), WantsFile: true})
+	_ = tf.String("debug-term-size", "", "skipped for test", tabflags.AutoComplete{Choices: []string{"15x80", "20x85", "HxW"}})
+	_ = tf.Bool("follow", false, "skipped for test")
+	_ = tf.Int("debug-fps", 240, "skipped for test")
+	_ = tf.Bool("logarithmic", false, "skipped for test")
+	return Command{Cmd: "acci-ping", Fs: tf}
+}
+
+//nolint:staticcheck
+func make_drawframe_Flags() Command {
+	f := flag.NewFlagSet("", flag.ContinueOnError)
+	tf := tabflags.NewAutoCompleteFlagSet(f, true, ".go")
+	_ = application.NewSharedFlags(tf)
+	_ = tf.Bool("debug-follow", false, "skipped for test")
+	_ = tf.String("term-size", "", "skipped for test",
+		tabflags.AutoComplete{Choices: []string{"15x80", "20x85", "HxW"}})
+	_ = tf.String("theme", "", "skipped for test",
+		tabflags.AutoComplete{Choices: themes.GetBuiltInNames(), WantsFile: true})
+	_ = tf.Bool("log-scale", false, "skipped for test")
+	return Command{Cmd: "drawframe", Fs: tf}
+}
+
+//nolint:staticcheck
+func make_version_Flags() Command {
+	return Command{Cmd: "version", Fs: nil}
+}
+
+func filesByExt(ext string) []string {
+	entries, err := os.ReadDir("./")
+	if err != nil {
+		log.Fatal(err)
+	}
+	files := sliceutils.Map(entries, func(d os.DirEntry) string { return d.Name() })
+	return sliceutils.Filter(files, func(f string) bool { return ext == "" || filepath.Ext(f) == ext })
+}
+
+func assertEqual(t *testing.T, expected, actual []string) {
+	t.Helper()
+	slices.Sort(actual)
+	slices.Sort(expected)
+	assert.DeepEqual(t, actual, expected)
+}

--- a/cmd/tab_completion/tabflags/tabflags.go
+++ b/cmd/tab_completion/tabflags/tabflags.go
@@ -1,0 +1,141 @@
+// Use of this source code is governed by a GPL-2 license that can be found in the LICENSE file.
+//
+// Copyright 2025 Lexer747
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package tabflags
+
+import (
+	"flag"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/Lexer747/acci-ping/utils/iterutils"
+)
+
+type AutoComplete struct {
+	Choices   []string
+	WantsFile bool
+	FileExt   string
+}
+
+type Flag struct {
+	// Name is the actual name as it appears on the CLI without the dash.
+	Name string
+	// AutoComplete specifies if the flag has any auto complete options.
+	AutoComplete *AutoComplete
+}
+
+// FlagSet is an extension of [flag.FlagSet] that enables auto completion providers for a command.
+type FlagSet struct {
+	*flag.FlagSet
+
+	flags    []Flag
+	nameToAc map[string]*AutoComplete
+
+	wantsFile bool
+	fileExt   string
+}
+
+// NewAutoCompleteFlagSet wraps a [flag.FlagSet] with autocomplete configuration, if [wantsFile] is set then
+// it's expected that the overall command wants a file so autocomplete suggestions from the working dir will
+// be given. If [fileExt] is set then only the files which match the extension are suggested.
+func NewAutoCompleteFlagSet(f *flag.FlagSet, wantsFile bool, fileExt string) *FlagSet {
+	return &FlagSet{
+		FlagSet:   f,
+		flags:     []Flag{},
+		nameToAc:  map[string]*AutoComplete{},
+		wantsFile: wantsFile,
+		fileExt:   fileExt,
+	}
+}
+
+// WantsFile returns true if this flag set wants a file as a free form arg.
+func (f *FlagSet) WantsFile() bool {
+	return f.wantsFile
+}
+
+// FileExt returns the specified file extensions to look for if [FlagSet.WantsFile] returns true.
+func (f *FlagSet) FileExt() string {
+	return f.fileExt
+}
+
+// GetAutoCompleteFor returns the autocomplete configuration for the given CLI flag. Returns the nil if the
+// param isn't found or not autocomplete config exists.
+func (f *FlagSet) GetAutoCompleteFor(flagName string) *AutoComplete {
+	ac, ok := f.nameToAc[strings.TrimPrefix(flagName, "-")]
+	if !ok {
+		return nil
+	}
+	return ac
+}
+
+// GetNames returns all the names that this flag set knows about, skipping "-debug" prefix unless
+// [includeDebug] is true. Also skips any names in [toSkip].
+func (f *FlagSet) GetNames(includeDebug bool, toSkip []string) []string {
+	keys := maps.Keys(f.nameToAc)
+	withDash := iterutils.Map(keys, func(n string) string {
+		return "-" + n
+	})
+	filtered := iterutils.Filter(withDash, func(n string) bool {
+		if !includeDebug && strings.HasPrefix(n, "-debug") {
+			return false
+		}
+		return !slices.Contains(toSkip, n)
+	})
+	names := slices.Collect(filtered)
+	slices.Sort(names)
+	return names
+}
+
+func (f *FlagSet) Has(flagName string) bool {
+	_, has := f.nameToAc[strings.TrimPrefix(flagName, "-")]
+	return has
+}
+
+// String see [FlagSet.String], also pass the autocomplete configuration.
+//
+// [FlagSet.String]: https://pkg.go.dev/flag#String
+func (f *FlagSet) String(name string, value string, usage string, ac AutoComplete) *string {
+	ret := f.FlagSet.String(name, value, usage)
+	f.addAc(name, &ac)
+	return ret
+}
+
+// Bool see [FlagSet.Bool]
+//
+// [FlagSet.Bool]: https://pkg.go.dev/flag#Bool
+func (f *FlagSet) Bool(name string, value bool, usage string) *bool {
+	ret := f.FlagSet.Bool(name, value, usage)
+	f.addAc(name, nil)
+	return ret
+}
+
+// Bool see [FlagSet.Float64]
+//
+// [FlagSet.Float64]: https://pkg.go.dev/flag#Float64
+func (f *FlagSet) Float64(name string, value float64, usage string) *float64 {
+	ret := f.FlagSet.Float64(name, value, usage)
+	f.addAc(name, nil)
+	return ret
+}
+
+// Bool see [FlagSet.Int]
+//
+// [FlagSet.Int]: https://pkg.go.dev/flag#Int
+func (f *FlagSet) Int(name string, value int, usage string) *int {
+	ret := f.FlagSet.Int(name, value, usage)
+	f.addAc(name, nil)
+	return ret
+}
+
+func (f *FlagSet) addAc(name string, ac *AutoComplete) {
+	flag := Flag{
+		Name:         name,
+		AutoComplete: ac,
+	}
+	f.flags = append(f.flags, flag)
+	f.nameToAc[name] = ac
+}

--- a/graph/data/data.go
+++ b/graph/data/data.go
@@ -349,11 +349,15 @@ func (r *Runs) Summary(getTimestamp func(int64) time.Time) string {
 func (r *Run) withTimestamp(str string, getTimestamp func(int64) time.Time) string {
 	end := getTimestamp(r.LongestIndexEnd)
 	// G115 the input for longest comes from int64 indexes anyway
-	begin := getTimestamp(r.LongestIndexEnd - int64(r.Longest-1)) //nolint:gosec
+	beginIndex := r.LongestIndexEnd - (int64(r.Longest) - 1) //nolint:gosec
+	if r.LongestIndexEnd == beginIndex || r.Longest == 0 {
+		return fmt.Sprintf("%s %d", str, r.Longest)
+	}
+	begin := getTimestamp(beginIndex)
 	span := TimeSpan{
 		Begin:    begin,
 		End:      end,
-		Duration: 0,
+		Duration: end.Sub(begin),
 	}
 	return fmt.Sprintf("%s %d %s", str, r.Longest, span.String())
 }

--- a/gui/themes/theme_embed.go
+++ b/gui/themes/theme_embed.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/Lexer747/acci-ping/terminal/ansi"
 	"github.com/Lexer747/acci-ping/terminal/typography"
@@ -34,7 +35,7 @@ func ParseThemeFromJSON(data []byte) (Theme, error) {
 // DescribeBuiltins gives a detailed slice of strings, where each string represents a builtin theme and it's
 // colour palate.
 func DescribeBuiltins() []string {
-	slices.SortFunc(builtIns, func(a, b themeJSON) int { return cmp.Compare(a.Name, b.Name) })
+	sortBuiltins()
 	return sliceutils.Map(builtIns, func(t themeJSON) string {
 		theme := check.Must(t.Theme())
 		const demo = typography.Block + typography.Block
@@ -48,8 +49,20 @@ func DescribeBuiltins() []string {
 	})
 }
 
+var sortBuiltIns = sync.Once{}
 var builtIns = []themeJSON{}
 var builtInsLookup = map[string]Theme{}
+
+func GetBuiltInNames() []string {
+	sortBuiltins()
+	return sliceutils.Map(builtIns, func(t themeJSON) string { return t.Name })
+}
+
+func sortBuiltins() {
+	sortBuiltIns.Do(func() {
+		slices.SortFunc(builtIns, func(a, b themeJSON) int { return cmp.Compare(a.Name, b.Name) })
+	})
+}
 
 func normalizeName(s string) string {
 	return strings.ToLower(strings.Trim(s, " "))

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -19,6 +19,10 @@ fi
 # Keep these names in sync, manually updating them if required with the go variables. Also Keep alphabetically sorted.
 BRANCH=$(git branch --show-current)
 COMMIT=$(git rev-parse HEAD)
+git diff-files --quiet &> /dev/null
+if [[ $? != 0 ]]; then
+	COMMIT="$COMMIT~dirty"
+fi
 GO_VERSION=$(go version)
 TAG=$(git describe --tags "$(git rev-list --tags --max-count=1)")
 TIMESTAMP=$(date --rfc-3339=ns)

--- a/tools/sub-command-test.sh
+++ b/tools/sub-command-test.sh
@@ -29,9 +29,9 @@ function test-cli {
 	fi
 	exitCode=$?
 	if [[ $exitCode == 0 ]]; then
-		echo -e "${Green}Success${ColorOff} for $*"
+		echo -e "${Green}Success${ColorOff} for 'acci-ping $*'"
 	else
-		echo -e "${Red}Failed${ColorOff} $exitCode for ./out/linux/amd64/acci-ping-linux-amd64 $*"
+		echo -e "${Red}Failed${ColorOff} $exitCode for './out/linux/amd64/acci-ping-linux-amd64 $*'"
 	fi
 	return $exitCode
 }

--- a/utils/application/application.go
+++ b/utils/application/application.go
@@ -7,7 +7,6 @@
 package application
 
 import (
-	"flag"
 	"io"
 	"log/slog"
 	"os"
@@ -16,6 +15,7 @@ import (
 	"runtime/trace"
 	"strings"
 
+	"github.com/Lexer747/acci-ping/cmd/tab_completion/tabflags"
 	"github.com/Lexer747/acci-ping/gui/themes"
 	"github.com/Lexer747/acci-ping/terminal"
 	"github.com/Lexer747/acci-ping/utils/check"
@@ -78,13 +78,13 @@ type SharedFlags struct {
 	memprofile  *string
 }
 
-func NewSharedFlags(f *flag.FlagSet) *SharedFlags {
+func NewSharedFlags(tf *tabflags.FlagSet) *SharedFlags {
 	return &SharedFlags{
-		cpuprofile:  f.String("debug-cpuprofile", "", "write cpu profile to `file`"),
-		debugStrict: f.Bool("debug-strict", false, "enables more strict operation in which warnings turn into crashes."),
-		logFile:     f.String("debug-log", "", "write logs to `file`. (default no logs written)"),
-		memprofile:  f.String("debug-memprofile", "", "write memory profile to `file`"),
-		helpDebug:   f.Bool("help-debug", false, "prints all additional debug arguments"),
+		cpuprofile:  tf.String("debug-cpuprofile", "", "write cpu profile to `file`", tabflags.AutoComplete{WantsFile: true}),
+		debugStrict: tf.Bool("debug-strict", false, "enables more strict operation in which warnings turn into crashes."),
+		logFile:     tf.String("debug-log", "", "write logs to `file`. (default no logs written)", tabflags.AutoComplete{WantsFile: true}),
+		memprofile:  tf.String("debug-memprofile", "", "write memory profile to `file`", tabflags.AutoComplete{WantsFile: true}),
+		helpDebug:   tf.Bool("help-debug", false, "prints all additional debug arguments"),
 	}
 }
 

--- a/utils/exit/exit.go
+++ b/utils/exit/exit.go
@@ -8,7 +8,6 @@ package exit
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
 )
 
@@ -16,7 +15,6 @@ import (
 // not nil the program will exit and print the error which caused the issue.
 func OnError(err error) {
 	if err != nil {
-		slog.Error(fmt.Sprintf("Exiting with %d", errCode), "err", err.Error())
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(errCode)
 	}
@@ -25,7 +23,6 @@ func OnError(err error) {
 // OnErrorMsg is like [OnError] but has a custom message when err is not nil.
 func OnErrorMsg(err error, msg string) {
 	if err != nil {
-		slog.Error(fmt.Sprintf("Exiting with %d", errCode), "err", err.Error(), "msg", msg)
 		fmt.Fprintf(os.Stderr, msg+": %s", err.Error())
 		os.Exit(errCode)
 	}
@@ -34,7 +31,6 @@ func OnErrorMsg(err error, msg string) {
 // OnErrorMsgf is like [OnErrorMsg] but will format the string according to printf before writing it.
 func OnErrorMsgf(err error, format string, args ...any) {
 	if err != nil {
-		slog.Error(fmt.Sprintf("Exiting with %d", errCode), "err", err.Error(), "msg", fmt.Sprintf(format, args...))
 		fmt.Fprintf(os.Stderr, fmt.Sprintf(format, args...)+": %s", err.Error())
 		os.Exit(errCode)
 	}

--- a/utils/iterutils/iterutils.go
+++ b/utils/iterutils/iterutils.go
@@ -1,0 +1,34 @@
+// Use of this source code is governed by a GPL-2 license that can be found in the LICENSE file.
+//
+// Copyright 2025 Lexer747
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package iterutils
+
+import "iter"
+
+// Map returns a new sequence where every value from the original sequence is transformed by f.
+func Map[In any, Out any](s iter.Seq[In], f func(In) Out) iter.Seq[Out] {
+	return func(yield func(Out) bool) {
+		for in := range s {
+			if !yield(f(in)) {
+				return
+			}
+		}
+	}
+}
+
+// Filter returns a new sequence only containing values from the original sequence for which the predicate f
+// returns true.
+func Filter[T any](s iter.Seq[T], f func(T) bool) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for in := range s {
+			if f(in) {
+				if !yield(in) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/utils/iterutils/iterutils_test.go
+++ b/utils/iterutils/iterutils_test.go
@@ -1,0 +1,30 @@
+// Use of this source code is governed by a GPL-2 license that can be found in the LICENSE file.
+//
+// Copyright 2025 Lexer747
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package iterutils_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/Lexer747/acci-ping/utils/iterutils"
+	"gotest.tools/v3/assert"
+)
+
+func TestMap(t *testing.T) {
+	t.Parallel()
+	input := slices.Values([]string{"a", "b", "c"})
+	expected := []string{"@a", "@b", "@c"}
+	actual := slices.Collect(iterutils.Map(input, func(s string) string { return "@" + s }))
+	assert.DeepEqual(t, expected, actual)
+}
+func TestFilter(t *testing.T) {
+	t.Parallel()
+	input := slices.Values([]string{"a", "b", "c"})
+	expected := []string{"b"}
+	actual := slices.Collect(iterutils.Filter(input, func(s string) bool { return s == "b" }))
+	assert.DeepEqual(t, expected, actual)
+}

--- a/utils/sliceutils/sliceutils.go
+++ b/utils/sliceutils/sliceutils.go
@@ -107,3 +107,29 @@ func SplitN[S ~[]T, T any](slice S, splitAfterN int) []S {
 	}
 	return ret
 }
+
+// Filter returns a shallow clone of [slice] where only the values which return true from the predicate are
+// included.
+func Filter[S ~[]T, T any](slice S, useInOutput func(T) bool) S {
+	ret := make(S, 0)
+	for _, item := range slice {
+		if useInOutput(item) {
+			ret = append(ret, item)
+		}
+	}
+	return ret
+}
+
+// TakeRandom returns a random element from the slice, or the zero value if the slice is empty.
+//
+// This is not a cryptographically secure random, do not use this for security.
+func TakeRandom[S ~[]T, T any](slice S) T {
+	if len(slice) <= 0 {
+		return *new(T)
+	}
+	// G404 warned about in the doc comment
+
+	//nolint:gosec
+	dealersChoice := rand.IntN(len(slice) - 1)
+	return slice[dealersChoice]
+}


### PR DESCRIPTION
This patch adds tab based autocomplete for arguments :)

This requires the `acci-ping` script to be given the shell, in bash's case this involves running:
```
sudo cp ./cmd/tab-completion/acci-ping /etc/bash_completion.d/acci-ping
```
And re-sourcing your `bashrc`.

Also fixes a panic with a single value when running the summary.