### PR TITLE
Save Memory with `fieldalignment`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5.3.0
       with:
-        go-version: 'stable'
+        go-version: '1.25.0'
 
     - name: Build
       run: ./tools/build.sh
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5.3.0
       with:
-        go-version: 'stable'
+        go-version: '1.25.0'
 
     - name: Test
       run: go test -race ./...
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5.3.0
         with:
-          go-version: 'stable'
+          go-version: '1.25.0'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7.0.0
         with:
@@ -53,3 +53,20 @@ jobs:
           # This linter works based on the file modification when running under github actions because it's
           # not given full access to the git history and therefore gets the wrong date for all files.
           args: --disable goheader
+
+  fieldalignment:
+    name: fieldalignment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5.3.0
+        with:
+          go-version: '1.25.0'
+
+      - name: install fieldalignment
+        run: go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest
+
+      - name: check for diff
+        run: $GITHUB_WORKSPACE/tools/fieldalignment-lint.sh

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,7 @@ linters:
   disable:
     - cyclop
     - durationcheck
+    - embeddedstructfieldcheck # we use [fieldalignment] instead
     - errname
     - exhaustruct
     - forbidigo

--- a/cmd/subcommands/acci-ping/gui.go
+++ b/cmd/subcommands/acci-ping/gui.go
@@ -13,8 +13,8 @@ import (
 
 type GUI struct {
 	listeningChars map[rune]terminal.ConditionalListener
-	fallbacks      []terminal.Listener
 	GUIState       *gui.GUIState
+	fallbacks      []terminal.Listener
 }
 
 func newGUIState() *GUI {

--- a/cmd/tab_completion/tab_completion.go
+++ b/cmd/tab_completion/tab_completion.go
@@ -29,8 +29,8 @@ const debug = false
 const AutoCompleteString = "b2827fc8fc8c8267cb15f5a925de7e4712aa04ef2fbd43458326b595d66a36d9" // sha256 of `autoCompleteString`
 
 type Command struct {
-	Cmd string
 	Fs  *tabflags.FlagSet
+	Cmd string
 }
 
 // Run will for a given command line input, write to stdout the autocomplete suggestion for the input [base]

--- a/cmd/tab_completion/tabflags/tabflags.go
+++ b/cmd/tab_completion/tabflags/tabflags.go
@@ -16,27 +16,26 @@ import (
 )
 
 type AutoComplete struct {
+	FileExt   string
 	Choices   []string
 	WantsFile bool
-	FileExt   string
 }
 
 type Flag struct {
-	// Name is the actual name as it appears on the CLI without the dash.
-	Name string
 	// AutoComplete specifies if the flag has any auto complete options.
 	AutoComplete *AutoComplete
+	// Name is the actual name as it appears on the CLI without the dash.
+	Name string
 }
 
 // FlagSet is an extension of [flag.FlagSet] that enables auto completion providers for a command.
 type FlagSet struct {
 	*flag.FlagSet
 
-	flags    []Flag
-	nameToAc map[string]*AutoComplete
-
-	wantsFile bool
+	nameToAc  map[string]*AutoComplete
 	fileExt   string
+	flags     []Flag
+	wantsFile bool
 }
 
 // NewAutoCompleteFlagSet wraps a [flag.FlagSet] with autocomplete configuration, if [wantsFile] is set then

--- a/graph/data/data.go
+++ b/graph/data/data.go
@@ -20,13 +20,13 @@ import (
 )
 
 type Data struct {
-	URL         string
 	Header      *Header
 	Network     *Network
+	Runs        *Runs
+	URL         string
 	InsertOrder []DataIndexes
 	Blocks      []*Block
 	TotalCount  int64
-	Runs        *Runs
 	PingsMeta   version
 }
 

--- a/graph/data/data_test.go
+++ b/graph/data/data_test.go
@@ -206,16 +206,15 @@ type BlockTest struct {
 }
 
 type DataTestCase struct {
-	Values             []ping.PingResults
-	BlockSize          int
-	ExpectedGraphSpan  data.TimeSpan
-	ExpectedGraphStats data.Stats
-	ExpectedPacketLoss float64
-	ExpectedTotalCount int
 	ExpectedRuns       data.Runs
 	BlockTest          *BlockTest
-
-	ExpectedSummary string
+	ExpectedGraphSpan  data.TimeSpan
+	ExpectedSummary    string
+	Values             []ping.PingResults
+	ExpectedGraphStats data.Stats
+	BlockSize          int
+	ExpectedPacketLoss float64
+	ExpectedTotalCount int
 }
 
 // A fixed time stamp to make all testing relative too

--- a/graph/data/serialisation_test.go
+++ b/graph/data/serialisation_test.go
@@ -170,9 +170,9 @@ func testCompacter(t th.T, start, empty data.Compact) {
 }
 
 type FileTest struct {
+	tz              *time.Location
 	FileName        string
 	ExpectedSummary string
-	tz              *time.Location
 }
 
 func (ft FileTest) Run(t *testing.T) {

--- a/graph/draw_window.go
+++ b/graph/draw_window.go
@@ -62,12 +62,11 @@ const (
 )
 
 type label struct {
+	symbol string
+	text   string
 	coords
-
-	symbol      string
-	text        string
-	leftJustify bool
 	colour      colour
+	leftJustify bool
 }
 
 type colour int

--- a/graph/drawing.go
+++ b/graph/drawing.go
@@ -163,10 +163,10 @@ func translate(p ping.PingDataPoint, x *XAxisSpanInfo, y drawingYAxis, s termina
 }
 
 type gradientState struct {
+	lastGoodSpan           *XAxisSpanInfo
 	lastGoodIndex          int64
 	lastGoodTerminalWidth  int
 	lastGoodTerminalHeight int
-	lastGoodSpan           *XAxisSpanInfo
 }
 
 func (g gradientState) set(i int64, x, y int, s *XAxisSpanInfo) gradientState {

--- a/graph/graph_file_test.go
+++ b/graph/graph_file_test.go
@@ -39,11 +39,11 @@ const (
 )
 
 type FileTest struct {
+	TimeZoneOfFile   *time.Location
 	FileName         string
 	Sizes            []terminal.Size
-	OnlyDoLinear     bool
-	TimeZoneOfFile   *time.Location
 	TerminalWrapping th.TerminalWrapping
+	OnlyDoLinear     bool
 }
 
 var StandardTestSizes = []terminal.Size{

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -189,9 +189,9 @@ func TestThousandsDrawing(t *testing.T) {
 }
 
 type DrawingTest struct {
-	Size         terminal.Size
-	Values       []ping.PingDataPoint
 	ExpectedFile string
+	Values       []ping.PingDataPoint
+	Size         terminal.Size
 }
 
 //nolint:unused

--- a/graph/graphdata/graphdata.go
+++ b/graph/graphdata/graphdata.go
@@ -25,9 +25,9 @@ import (
 
 type GraphData struct {
 	data      *data.Data
+	m         *sync.Mutex
 	spans     []*SpanInfo
 	spanIndex int
-	m         *sync.Mutex
 }
 
 func NewGraphData(d *data.Data) *GraphData {
@@ -106,9 +106,9 @@ func (gd *GraphData) LockFreeIter(followLatestSpan bool) *Iter {
 }
 
 type Iter struct {
-	Total  int64
 	d      *data.Data
 	spans  Spans
+	Total  int64
 	offset int64
 }
 

--- a/graph/graphdata/graphdata_test.go
+++ b/graph/graphdata/graphdata_test.go
@@ -221,8 +221,8 @@ func (test TimeSpanTest) Run(t *testing.T) {
 
 type TimeSpanFileTest struct {
 	File              string
-	ExpectedSpanCount int
 	ExpectedSpans     []*data.TimeSpan
+	ExpectedSpanCount int
 }
 
 func (test TimeSpanFileTest) Run(t *testing.T) {

--- a/graph/spinner.go
+++ b/graph/spinner.go
@@ -23,8 +23,8 @@ var spinnerArray = [...]string{
 }
 
 type spinner struct {
-	spinnerIndex       int
 	timestampLastDrawn time.Time
+	spinnerIndex       int
 }
 
 func (s *spinner) spinner(size terminal.Size) string {

--- a/graph/xAxis.go
+++ b/graph/xAxis.go
@@ -23,19 +23,19 @@ import (
 )
 
 type XAxisSpanInfo struct {
-	spans     []*graphdata.SpanInfo
 	spanStats *data.Stats
 	pingStats *data.Stats
 	timeSpan  *data.TimeSpan
+	spans     []*graphdata.SpanInfo
 	startX    int
 	endX      int
 	width     int
 }
 
 type drawingXAxis struct {
-	size        int
-	spans       []*XAxisSpanInfo
 	overallSpan *data.TimeSpan
+	spans       []*XAxisSpanInfo
+	size        int
 }
 
 type xAxisIter struct {

--- a/graph/yAxis.go
+++ b/graph/yAxis.go
@@ -22,8 +22,8 @@ import (
 )
 
 type drawingYAxis struct {
-	size      int
 	stats     *data.Stats
+	size      int
 	labelSize int
 	scale     YAxisScale
 }

--- a/gui/box_test.go
+++ b/gui/box_test.go
@@ -214,11 +214,11 @@ func (tc *testCase) getOutputFileName() string {
 }
 
 type testCase struct {
+	text     []string
+	position gui.Position
 	size     terminal.Size
 	style    gui.Style
-	position gui.Position
 	align    gui.HorizontalAlignment
-	text     []string
 	result   hash
 }
 

--- a/gui/notifications.go
+++ b/gui/notifications.go
@@ -25,9 +25,9 @@ import (
 type Notification[T any] struct {
 	m        *sync.Mutex
 	storage  map[int]stored[T]
-	key      int
 	drawFunc func(terminal.Size, []T) Draw
 	lastSize terminal.Size
+	key      int
 }
 
 // NewNotification builds a new thread safe collection of [T]. The function passed will be called with a

--- a/gui/themes/colours_test.go
+++ b/gui/themes/colours_test.go
@@ -48,9 +48,9 @@ green component out of range -3, should be within 0 and 255`)},
 }
 
 type CSSTest struct {
+	Err     error
 	input   string
 	R, G, B uint8
-	Err     error
 }
 
 func (tc CSSTest) Run(t *testing.T) {

--- a/gui/themes/themes_test.go
+++ b/gui/themes/themes_test.go
@@ -86,10 +86,10 @@ func CurryTrueColour(r, g, b uint8) func(s string) string {
 }
 
 type AnsiThemeTest struct {
-	Input        string
-	Output       func(s string) string
 	UnmarshalErr error
 	ImplErr      error
+	Output       func(s string) string
+	Input        string
 }
 
 const testString = "abcdefghijklmnopqrstuvwxyz"

--- a/ping/addr.go
+++ b/ping/addr.go
@@ -9,10 +9,9 @@ package ping
 import "net"
 
 type addr struct {
-	ip net.IP
-
 	asUDP *net.UDPAddr
 	asIP  *net.IPAddr
+	ip    net.IP
 }
 
 func New(addrType addressType, ip net.IP) *addr {

--- a/ping/api.go
+++ b/ping/api.go
@@ -22,16 +22,15 @@ import (
 )
 
 type Ping struct {
+	echoType      icmp.Type
+	echoReply     icmp.Type
 	connect       *icmp.PacketConn
-	addrType      addressType
-	id            uint16
+	addresses     *queryCache
 	currentURL    string
+	addrType      addressType
 	timeout       time.Duration
 	ratelimitTime time.Duration
-
-	echoType, echoReply icmp.Type
-
-	addresses *queryCache
+	id            uint16
 }
 
 // NewPing constructs a new Ping client which can perform accurate ping measurements. Either with
@@ -183,20 +182,20 @@ func (p *Ping) CreateFlexibleChannel(
 }
 
 type PingResults struct {
+	// InternalErr represents some problem with [ping] package internal state which didn't gracefully handle
+	// some network problem. Other network problems which are expected and represent dropped packets **should
+	// be** handled gracefully and will be reported in the [PingDataPoint] field in the [Dropped].
+	InternalErr error
 	// Data is the data about this ping, containing the time taken for round trip or details if the packet was
 	// dropped.
 	Data PingDataPoint
 	// IP is the address which this ping result was achieved from.
 	IP net.IP
-	// InternalErr represents some problem with [ping] package internal state which didn't gracefully handle
-	// some network problem. Other network problems which are expected and represent dropped packets **should
-	// be** handled gracefully and will be reported in the [PingDataPoint] field in the [Dropped].
-	InternalErr error
 }
 
 type PingDataPoint struct {
-	Duration   time.Duration
 	Timestamp  time.Time
+	Duration   time.Duration
 	DropReason Dropped
 }
 

--- a/ping/api_implementation.go
+++ b/ping/api_implementation.go
@@ -198,8 +198,8 @@ func (pt pingTimeout) Error() string { return "PingTimeout {" + pt.String() + "}
 
 func (p *Ping) pingRead(ctx context.Context, buffer []byte) (int, error) {
 	type read struct {
-		n   int
 		err error
+		n   int
 	}
 	c := make(chan read)
 	go func() {
@@ -301,9 +301,8 @@ var listenList = []listenerConfig{
 }
 
 type listenerConfig struct {
-	addressType
-
 	network, address string
+	addressType
 }
 
 type addressType int

--- a/terminal/parser.go
+++ b/terminal/parser.go
@@ -142,10 +142,9 @@ type parser struct {
 	Ctx          context.Context
 	ToStreamFrom io.Reader
 	Buffer       []byte
-
-	parserHead  int
-	pointer     int
-	bufferSlice []byte
+	bufferSlice  []byte
+	parserHead   int
+	pointer      int
 }
 
 // Consume the exact bytes passed, errors if the stream produced different bytes.

--- a/tools/fieldalignment-lint.sh
+++ b/tools/fieldalignment-lint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+ROOT=$(git rev-parse --show-toplevel)
+pushd "$ROOT" &> /dev/null || exit
+
+
+fieldalignment ./... &> /dev/null
+exitCode=$?
+if [[ $exitCode != 0 ]]; then
+    fieldalignment -fix -diff ./...
+else
+    echo "fieldalignment good :)"
+fi
+
+popd &> /dev/null || exit
+exit $exitCode

--- a/tools/verify.sh
+++ b/tools/verify.sh
@@ -33,3 +33,4 @@ if [ $testsExitCode -eq 0 ] || [[ "$1" == "update" ]]; then
 fi
 
 "$ROOT"/tools/sub-command-test.sh
+"$ROOT"/tools/fieldalignment-lint.sh

--- a/utils/numeric/numeric_test.go
+++ b/utils/numeric/numeric_test.go
@@ -21,10 +21,12 @@ import (
 func TestNormalize(t *testing.T) {
 	t.Parallel()
 	type Case struct {
-		Min, Max       float64
-		NewMin, NewMax float64
-		Inputs         []float64
-		Expected       []float64
+		Inputs   []float64
+		Expected []float64
+		Min      float64
+		Max      float64
+		NewMin   float64
+		NewMax   float64
 	}
 	cases := []Case{
 		{

--- a/utils/sliceutils/sliceutils_test.go
+++ b/utils/sliceutils/sliceutils_test.go
@@ -67,8 +67,8 @@ func TestSplitN(t *testing.T) {
 
 type testCase[T comparable] struct {
 	Input  []T
-	SplitN int
 	Output [][]T
+	SplitN int
 }
 
 func (tc testCase[T]) Run(t *testing.T) {

--- a/utils/th/helper_debug.go
+++ b/utils/th/helper_debug.go
@@ -17,8 +17,8 @@ type debug struct {
 }
 
 type debugItem struct {
-	sequence   []rune
 	command    string
+	sequence   []rune
 	startIndex int
 	endIndex   int
 }

--- a/utils/th/test_helper.go
+++ b/utils/th/test_helper.go
@@ -127,20 +127,19 @@ func EmulateTerminal(ansiText string, buffer []string, size terminal.Size, termi
 }
 
 type ansiState struct {
-	cursorRow, cursorColumn int
+	ansiText string
 	// buffer is the in memory representation of the terminal, each entry of the slice is a row.
-	buffer      []string
-	size        terminal.Size
-	ansiText    string
-	asRunes     []rune
-	head        int
-	outOfBounds bool
-
-	terminalWrapping TerminalWrapping
-
+	buffer  []string
+	asRunes []rune
 	// for errors in tests we accumulate this debug object which will store the runes processed to create the
 	// current terminal.
-	debug debug
+	debug            debug
+	size             terminal.Size
+	cursorRow        int
+	cursorColumn     int
+	head             int
+	terminalWrapping TerminalWrapping
+	outOfBounds      bool
 }
 
 func (a *ansiState) peekN(n int) rune     { return a.asRunes[a.head+n] }


### PR DESCRIPTION
This patch uses the `fieldalignment` tool to save memory across the board. I don't think this will dramatically improve performance but it's "free" memory savings. Most of the hot paths haven't changed because the savings are all related to moving pointers.

Including tests this saves 856 bytes. Excluding tests it's still 552 bytes saved. 

This patch also adds the `fieldalignment` lint to CI so that I actually maintain these savings.

Closes #26